### PR TITLE
Remove Occupation Exploit / Update Occupation Start

### DIFF
--- a/src/BM2/SiteBundle/Controller/ActionsController.php
+++ b/src/BM2/SiteBundle/Controller/ActionsController.php
@@ -958,30 +958,6 @@ class ActionsController extends Controller {
 	}
 
 	/**
-	  * @Route("/occupation/start", name="maf_settlement_occupation_start")
-	  */
-	public function occupationStartAction(Request $request) {
-		list($character, $settlement) = $this->get('dispatcher')->gateway('controlOccupationStartTest', true);
-		if (! $character instanceof Character) {
-			return $this->redirectToRoute($character);
-		}
-		$form = $this->createForm(new RealmSelectType($character->findRealms(), 'occupy'));
-		$form->handleRequest($request);
-		if ($form->isValid()) {
-			$data = $form->getData();
-			$targetrealm = $data['target'];
-
-			$result = $this->get('politics')->changeSettlementOccupier($character, $settlement, $targetrealm);
-			$this->getDoctrine()->getManager()->flush();
-			$this->addFlash('notice', $this->get('translator')->trans('event.settlement.occupier.start', [], 'communication'));
-			return $this->redirectToRoute('bm2_actions');
-		}
-		return $this->render('Settlement/occupationstart.html.twig', [
-			'settlement'=>$settlement, 'form'=>$form->createView()
-		]);
-	}
-
-	/**
 	  * @Route("/occupation/end", name="maf_settlement_occupation_end")
 	  */
 	public function occupationEndAction(Request $request) {

--- a/src/BM2/SiteBundle/Service/WarManager.php
+++ b/src/BM2/SiteBundle/Service/WarManager.php
@@ -841,8 +841,12 @@ class WarManager {
 							$this->interactions->characterEnterSettlement($char, $target, true);
 
 					}
-					if ($victor->getLeader()) {
-						$this->politics->changeSettlementOccupier($victor->getLeader(), $target, $siege->getRealm());
+					$leader = $victor->getLeader();
+					if (!$leader) {
+						$leader = $victor->getCharacters()->first(); #Get one at random.
+					}
+					if ($leader) {
+						$this->politics->changeSettlementOccupier($leader, $target, $siege->getRealm());
 					}
 					foreach ($target->getSuppliedUnits() as $unit) {
 						if ($unit->getCharacter() != $victor->getLeader() && $unit->getSettlement() != $target) {
@@ -888,8 +892,12 @@ class WarManager {
 							$this->interactions->characterEnterPlace($char, $target, true);
 
 					}
-					if ($victor->getLeader()) {
-						$this->politics->changePlaceOccupier($victor->getLeader(), $target, $siege->getRealm());
+					$leader = $victor->getLeader();
+					if (!$leader) {
+						$leader = $victor->getCharacters()->first(); #Get one at random.
+					}
+					if ($leader) {
+						$this->politics->changePlaceOccupier($leader, $target, $siege->getRealm());
 					}
 					foreach ($target->getUnits() as $unit) {
 						$this->milman->returnUnitHome($unit, 'defenselost', $victor->getLeader());


### PR DESCRIPTION
Sieges are now required to start an occupation. Starting an occupation is now smarter about finding a leader for it if the battlegroup leader somehow dies. That is to say, it now grabs someone at random, rather than completely just ignoring it.