### PR TITLE
Unit size does not affect combat power

### DIFF
--- a/src/BM2/SiteBundle/Service/CombatManager.php
+++ b/src/BM2/SiteBundle/Service/CombatManager.php
@@ -374,12 +374,7 @@ class CombatManager {
 
 		// TODO: heavy armour should reduce this a little
 		if ($sol) {
-			$fighters = $me->getAllInUnit()->count();
-			if ($fighters>1) {
-				$me->updateMeleePower($power * pow($fighters, 0.96)/$fighters);
-			} else {
-				$me->updateMeleePower($power);
-			}
+			$me->updateMeleePower($power);
 		}
 		return $power*$mod;
 	}
@@ -527,12 +522,7 @@ class CombatManager {
 		// TODO: heavy armour should reduce this quite a bit
 
 		if ($sol) {
-			$fighters = $me->getAllInUnit()->count();
-			if ($fighters>1) {
-				$me->updateRangedPower($power * pow($fighters, 0.96)/$fighters);
-			} else {
-				$me->updateRangedPower($power);
-			}
+			$me->updateRangedPower($power);
 		}
 
 		return $power*$mod;

--- a/src/BM2/SiteBundle/Service/CombatManager.php
+++ b/src/BM2/SiteBundle/Service/CombatManager.php
@@ -299,7 +299,7 @@ class CombatManager {
 		return [$result, $logs];
 	}
 
-	public function MeleePower($me, $sol = false, EquipmentType $weapon = null) {
+	public function MeleePower($me, $sol = false, EquipmentType $weapon = null, $groupSize = 1) {
 		$noble = false;
 		$act = false;
 		# $sol is just a bypass for "Is this a soldier instance" or not.
@@ -374,7 +374,11 @@ class CombatManager {
 
 		// TODO: heavy armour should reduce this a little
 		if ($sol) {
-			$me->updateMeleePower($power);
+			if ($groupSize>1) {
+				$me->updateMeleePower($power * pow($groupSize, 0.96)/$groupSize);
+			} else {
+				$me->updateMeleePower($power);
+			}
 		}
 		return $power*$mod;
 	}
@@ -445,7 +449,7 @@ class CombatManager {
 		return [$result, $logs];
 	}
 
-	public function RangedPower($me, $sol = false, EquipmentType $weapon = null) {
+	public function RangedPower($me, $sol = false, EquipmentType $weapon = null, $groupSize = 1) {
 		$noble = false;
 		# $sol is just a bypass for "Is this a soldier instance" or not.
 		if ($sol) {
@@ -522,7 +526,11 @@ class CombatManager {
 		// TODO: heavy armour should reduce this quite a bit
 
 		if ($sol) {
-			$me->updateRangedPower($power);
+			if ($groupSize>1) {
+				$me->updateRangedPower($power * pow($groupSize, 0.96)/$groupSize);
+			} else {
+				$me->updateRangedPower($power);
+			}
 		}
 
 		return $power*$mod;


### PR DESCRIPTION
This change makes it so that soldier combat power is unaffected by the size of the unit.

It makes no sense for four units of 50 soldiers each to be stronger than one unit of 200.