### PR TITLE
adding marsh drainage building

### DIFF
--- a/app/Resources/translations/economy.en.yml
+++ b/app/Resources/translations/economy.en.yml
@@ -57,6 +57,7 @@ building:
  Imperial Seat: Imperial Seat
  Inn: Inn
  Irrigation Ditches: Irrigation Ditches
+ Marsh Drainage: Marsh Drainage
  Leather Tanner: Leather Tanner
  Library: Library
  List Field: List Field
@@ -220,6 +221,8 @@ description:
    A series of small canals and ditches bringing water from a river deeper into the nearby farmland, which will improve
    fertility, but at the cost of constant management tying up manpower that could work the fields otherwise. Not very
    useful in already fertile regions, but very useful in less fertile ones.
+ Marsh Drainage: >
+   A system of drainage ditches and fillings to make the fertile marsh for suitable for agricultural activity.
  Leather Tanner: >
    A basic craftsman who turns animal hides into leather and simple leather products.
  Library: >
@@ -333,6 +336,7 @@ condition:
  Fishery:            Can only be built at the coast (both ocean and lakes).
  Fortress:           Cannot be built in marshland.
  Irrigation Ditches: Can only be built near rivers, can't be built in mountains or marshes.
+ Marsh Drainage:     Can only be built on marshes.
  Local Seat:         Can only be built in the capital of a realm.
  Lumber Yard:        Can only be built in forests.
  Quarry:             Not yet enabled/complete.

--- a/src/BM2/SiteBundle/DataFixtures/ORM/LoadBuildingData.php
+++ b/src/BM2/SiteBundle/DataFixtures/ORM/LoadBuildingData.php
@@ -68,6 +68,7 @@ class LoadBuildingData extends AbstractFixture implements OrderedFixtureInterfac
 		'Fishery'           	=> array('auto' =>   1800, 'min' =>    500, 'work' =>   6000, 'ratio' =>   800, 'builtin' => array('city'), 'requires' => array('Carpenter','Blacksmith','Dirt Streets'), 'conditions'=>true),
 		'Lumber Yard'           => array('auto' =>      0, 'min' =>    600, 'work' =>   8000, 'ratio' =>  1400, 'builtin' => array('city'), 'requires' => array('Carpenter','Blacksmith','Dirt Streets'), 'conditions'=>true),
 		'Irrigation Ditches'    => array('auto' =>   3000, 'min' =>    200, 'work' =>  15000, 'ratio' =>   500, 'builtin' => array('city'), 'requires' => array('Carpenter','Blacksmith'), 'conditions'=>true),
+		'Marsh Drainage'    	=> array('auto' =>   0, 'min' =>    400, 'work' =>  20000, 'ratio' =>   500, 'builtin' => array('city'), 'requires' => array('Carpenter','Blacksmith'), 'conditions'=>true),
 
 		'Local Seat'		=> array('auto' =>	0, 'min' =>    100, 'work' =>   5000, 'ratio' =>   500, 'builtin' => array('city'), 'defenses' => 5, 'requires' => array('Carpenter','Dirt Streets','Wood Wall'), 'conditions'=>true),
 		'Regional Seat'		=> array('auto' =>	0, 'min' =>   1000, 'work' => 500000, 'ratio' =>   500, 'builtin' => array('city'), 'defenses' => 5, 'requires' => array('Local Seat','Mason','Blacksmith','Paved Streets','Inn','School','Town Hall','Guardhouse','Wood Castle'), 'conditions'=>true),
@@ -146,6 +147,7 @@ class LoadBuildingData extends AbstractFixture implements OrderedFixtureInterfac
 		'Fishery'               => array('wood'=>array('construction'=>800), 'metal'=>array('construction'=>100), 'goods'=>array('construction'=>50), 'food'=>array('provides'=>50, 'bonus'=>5)),
 		'Lumber Yard'           => array('wood'=>array('construction'=>500, 'bonus'=>4), 'metal'=>array('construction'=>100, 'operation'=>1)),
 		'Irrigation Ditches'    => array('wood'=>array('construction'=>600), 'metal'=>array('construction'=>25), 'goods'=>array('construction'=>20), 'food'=>array('provides'=>100, 'bonus'=>1)),
+		'Marsh Drainage'    	=> array('wood'=>array('construction'=>1000), 'metal'=>array('construction'=>100), 'goods'=>array('construction'=>50), 'food'=>array('provides'=>50, 'bonus'=>5)),
 
 		'Local Seat'		=> array('wood'=>array('construction'=>2000, 'operation'=>10), 'metal'=>array('construction'=>300), 'money'=>array('construction'=>100, 'provides'=>2, 'bonus'=>1), 'food'=>array('bonus'=>3)),
 		'Regional Seat'		=> array('wood'=>array('construction'=>8000, 'operation'=>20), 'metal'=>array('construction'=>1000, 'bonus'=>5), 'money'=>array('construction'=>1000, 'provides'=>2, 'bonus'=>3), 'food'=>array('bonus'=>3)),

--- a/src/BM2/SiteBundle/Service/CharacterManager.php
+++ b/src/BM2/SiteBundle/Service/CharacterManager.php
@@ -726,6 +726,9 @@ class CharacterManager {
 		foreach ($character->getBattlegroups() as $bg) {
 			$this->war_manager->removeCharacterFromBattlegroup($character, $bg);
 		}
+		foreach ($character->getUnits() as $unit) {
+          		$this->returnUnitHome($unit, 'surrender', $character);
+      		}
 		$captor = $character->getPrisonerOf();
 		$character->setLocation($captor->getLocation());
 		$character->setInsideSettlement($captor->getInsideSettlement());

--- a/src/BM2/SiteBundle/Service/Dispatcher.php
+++ b/src/BM2/SiteBundle/Service/Dispatcher.php
@@ -2227,7 +2227,6 @@ class Dispatcher {
 
 
 	public function personalSurrenderTest() {
-		return array("name"=>"surrender.name", "description"=>"disabled because of abuse");
 		if ($this->getCharacter()->getPrisonerOf()) {
 			return array("name"=>"surrender.name", "description"=>"unavailable.prisoner");
 		}

--- a/src/BM2/SiteBundle/Service/Economy.php
+++ b/src/BM2/SiteBundle/Service/Economy.php
@@ -232,7 +232,13 @@ class Economy {
 					return false;
 				}
 				$geo = $settlement->getGeoData()->getBiome()->getName();
-				if ($geo == 'rock') {
+				if (in_array($geo, array('rock', 'marsh'))) {
+					return false;
+				}
+				break;
+			case 'marsh drainage': // only in marshes
+			$geo = $settlement->getGeoData()->getBiome()->getName();
+				if ($geo != 'marsh') {
 					return false;
 				}
 				break;

--- a/src/BM2/SiteBundle/Service/Economy.php
+++ b/src/BM2/SiteBundle/Service/Economy.php
@@ -227,7 +227,7 @@ class Economy {
 					return false;
 				}
 				break;
-			case 'irrigation ditches': // only near rivers, not in mountains
+			case 'irrigation ditches': // only near rivers, not in mountains or marshes
 				if ($settlement->getGeoData()->getRiver() == false) {
 					return false;
 				}

--- a/src/BM2/SiteBundle/Service/Economy.php
+++ b/src/BM2/SiteBundle/Service/Economy.php
@@ -227,12 +227,12 @@ class Economy {
 					return false;
 				}
 				break;
-			case 'irrigation ditches': // only near rivers, not in mountains or marshes
+			case 'irrigation ditches': // only near rivers, not in mountains
 				if ($settlement->getGeoData()->getRiver() == false) {
 					return false;
 				}
 				$geo = $settlement->getGeoData()->getBiome()->getName();
-				if (in_array($geo, array('rock', 'marsh'))) {
+				if ($geo == 'rock') {
 					return false;
 				}
 				break;


### PR DESCRIPTION
Adds in the marsh drainage building which takes more work hours and resources to build than both the fishery and irrigation ditches, yet only provides benefits comparable to the fishery.

This is because irrigation ditches are genuinely too good so it'd be better to have less things like them.

The marsh drainage building/project can be made in any marsh.