### PR TITLE
re-enabling manual surrender & adding units return/disband on capture

### DIFF
--- a/src/BM2/SiteBundle/Service/CharacterManager.php
+++ b/src/BM2/SiteBundle/Service/CharacterManager.php
@@ -726,6 +726,9 @@ class CharacterManager {
 		foreach ($character->getBattlegroups() as $bg) {
 			$this->war_manager->removeCharacterFromBattlegroup($character, $bg);
 		}
+		foreach ($character->getUnits() as $unit) {
+          		$this->returnUnitHome($unit, 'surrender', $character);
+      		}
 		$captor = $character->getPrisonerOf();
 		$character->setLocation($captor->getLocation());
 		$character->setInsideSettlement($captor->getInsideSettlement());

--- a/src/BM2/SiteBundle/Service/CharacterManager.php
+++ b/src/BM2/SiteBundle/Service/CharacterManager.php
@@ -727,7 +727,7 @@ class CharacterManager {
 			$this->war_manager->removeCharacterFromBattlegroup($character, $bg);
 		}
 		foreach ($character->getUnits() as $unit) {
-          		$this->returnUnitHome($unit, 'surrender', $character);
+          		$this->milman->returnUnitHome($unit, 'surrender', $character);
       		}
 		$captor = $character->getPrisonerOf();
 		$character->setLocation($captor->getLocation());

--- a/src/BM2/SiteBundle/Service/Dispatcher.php
+++ b/src/BM2/SiteBundle/Service/Dispatcher.php
@@ -2227,7 +2227,6 @@ class Dispatcher {
 
 
 	public function personalSurrenderTest() {
-		return array("name"=>"surrender.name", "description"=>"disabled because of abuse");
 		if ($this->getCharacter()->getPrisonerOf()) {
 			return array("name"=>"surrender.name", "description"=>"unavailable.prisoner");
 		}


### PR DESCRIPTION
could not get test environment to work to verify.

Removes the restriction Tom added from manually surrendering and makes it so that upon capture units are returned to their bases. If they do not have bases, they are disbanded.

Future plans is to make it possible to surrender while in a battle, yet currently it seems too easy to abuse. So limiting it to original function.